### PR TITLE
Fix API routing for Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,10 @@ services:
       - "4000:4000"
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        VITE_API_URL: "http://localhost:4000"
     depends_on:
       - backend
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,11 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
+
+# allow overriding API URL at build-time (default: backend on localhost)
+ARG VITE_API_URL="http://localhost:4000"
+ENV VITE_API_URL=${VITE_API_URL}
+
 RUN npm run build            # generates static files in /app/dist
 
 # ---------- runtime ----------


### PR DESCRIPTION
## Summary
- pass VITE_API_URL at build-time for the frontend image
- expose the build arg in docker-compose so requests use http://localhost:4000

## Testing
- `npx vitest run` *(fails: EHOSTUNREACH)*
- `npx jest` *(fails: EHOSTUNREACH)*
- `docker compose up --build` *(fails: `docker` not found)*