### PR TITLE
Fix API routing for Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - mongo-data:/data/db
 
   backend:
+    container_name: trivia-app-backend
     build: ./backend
     environment:
       - MONGO_URI=mongodb://mongo:27017/trivia
@@ -16,7 +17,11 @@ services:
       - "4000:4000"
 
   frontend:
-    build: ./frontend
+    container_name: trivia-app-frontend
+    build:
+      context: ./frontend
+      args:
+        VITE_API_URL: "http://localhost:4000"
     depends_on:
       - backend
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,10 +4,17 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
+
+# allow overriding API URL at build-time (default: backend on localhost)
+ARG VITE_API_URL="http://localhost:4000"
+ENV VITE_API_URL=${VITE_API_URL}
+
 RUN npm run build            # generates static files in /app/dist
 
 # ---------- runtime ----------
 FROM nginx:stable-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+# provide custom Nginx config with API proxy
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx","-g","daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,21 @@
+server {
+  listen 80;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Route API requests to backend service
+  location /api/ {
+    proxy_pass http://backend:4000/api/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+  }
+
+  # SPA fallback
+  location / {
+    try_files $uri /index.html;
+  }
+}


### PR DESCRIPTION
## Summary
- add nginx proxy config for the frontend
- copy nginx.conf in the frontend Dockerfile
- name backend and frontend containers in docker-compose

## Testing
- `npx vitest run` *(fails: EHOSTUNREACH)*
- `npx jest` *(fails: EHOSTUNREACH)*
- `docker compose up --build -d` *(fails: `docker` not found)*